### PR TITLE
some workarounds to allow rendering of windows when no pawns in colony

### DIFF
--- a/Source/WDYS/Dialog_ShowBuyable.cs
+++ b/Source/WDYS/Dialog_ShowBuyable.cs
@@ -37,7 +37,7 @@ namespace WDYS
             absorbInputAroundWindow = true;
             this.trader = trader;
             this.negotiator = negotiator;
-            negotiatorStat = this.negotiator.GetStatValue(StatDefOf.TradePriceImprovement);
+            negotiatorStat = this.negotiator != null ? this.negotiator.GetStatValue(StatDefOf.TradePriceImprovement) : 0f;
             this.settlement = settlement;
 
             TradeSession.playerNegotiator = this.negotiator;
@@ -79,7 +79,7 @@ namespace WDYS
             Rect pawnIconRow = new Rect(0f, 10f + num, 40f, 40f);
             Widgets.ThingIcon(pawnIconRow, negotiator);
             Rect pawnTextRow = new Rect(60f, 10f + num, windowRect.width - 60f, 40f);
-            Widgets.Label(pawnTextRow, "WDYS.Pawn".Translate(negotiator.NameFullColored, negotiatorStat.ToStringPercent()));
+            Widgets.Label(pawnTextRow, "WDYS.Pawn".Translate(negotiator?.NameFullColored ?? string.Empty, negotiatorStat.ToStringPercent()));
             num += 50f;
 
             // Draw settlement money

--- a/Source/WDYS/MainTabWindow_TradeStock.cs
+++ b/Source/WDYS/MainTabWindow_TradeStock.cs
@@ -117,7 +117,7 @@ namespace WDYS
             Rect pawnIconRow = new Rect(10f, 10f + num, 40f, 40f);
             Widgets.ThingIcon(pawnIconRow, negotiator);
             Rect pawnTextRow = new Rect(70f, 10f + num, windowRect.width - 70f, 40f);
-            Widgets.Label(pawnTextRow, "WDYS.Pawn".Translate(negotiator.NameFullColored, negotiatorStat.ToStringPercent()));
+            Widgets.Label(pawnTextRow, "WDYS.Pawn".Translate(negotiator?.NameFullColored ?? string.Empty, negotiatorStat.ToStringPercent()));
             num += 50f;
 
             Rect mainRect = new Rect(0f, 10f + num, inRect.width, inRect.height - num - 10f);


### PR DESCRIPTION
This is a workaround to fix the window render error when no pawn in colony.

There are still some issues for the workarounds.
1. There are still red errors in log `StatRequest for null thing` showing when opening the windows. Good news is it's not affecting the game rendering and is invisible unless in developer mod.
2. The prices are wrongly computed using the windows. The price advantage is shown as -38% in my case.

The cause for the red error is within `Dialog_ShowBuyable.cs:DrawPrice` the line:
```
string label = trad.GetPriceFor(TradeAction.PlayerBuys).ToStringMoney();
```

The this GetPriceFor function call will call `Tradeable::GetPriceFor` -> `Tradeable::InitPriceDataIfNeeded` 
```
...
priceGain_PlayerNegotiator = TradeSession.playerNegotiator.GetStatValue(StatDefOf.TradePriceImprovement);
...
```

I highly doubt it's the TradeSession.playerNegotiator value is null that causes this issue. However, I don't know how to fix it yet.

Hope this patch could help. Thank you so much for this great mod and all other mods you have been maintained.